### PR TITLE
Creates required directories under ./var

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 ln -sf docker-compose.dev.yml docker-compose.yml
+mkdir -p var/logs/ var/cache/ var/sessions/
 sudo rm -rf var/logs/* var/cache/* var/sessions/*
 docker-compose kill && docker-compose rm -f && docker-compose up -d --build
 docker-compose exec mawaqit_php  chmod 777 -R var/logs var/cache var/sessions


### PR DESCRIPTION
On first startup as a contributor, I faced the following issue:
```
Successfully tagged mawaqit_mawaqit_php:latest
Creating mawaqit_php                ... done
Creating mawaqit_maildev            ... done
Creating mawaqit_mysql              ... done
Creating mawaqit_nginx              ... done
Creating mawaqit_mawaqit_composer_1 ... done
chmod: cannot access 'var/logs': No such file or directory
chmod: cannot access 'var/cache': No such file or directory
chmod: cannot access 'var/sessions': No such file or directory
```

This PR simply adds the creations for the missing directories if they are missing.
